### PR TITLE
Handle optional columns, fixes #7

### DIFF
--- a/src/main/scala/io/underscore/jobby/job.scala
+++ b/src/main/scala/io/underscore/jobby/job.scala
@@ -22,6 +22,7 @@ case class Job(
   description       : String,
   adminEmailAddress : String,
   newsletter        : String,
-  companyName       : String
+  companyName       : String,
+  citizenship       : Option[String] = None
 )
 

--- a/src/main/scala/io/underscore/jobby/markdown.scala
+++ b/src/main/scala/io/underscore/jobby/markdown.scala
@@ -4,9 +4,9 @@ object Markdown {
 
   def instructionsText(job: Job): String =
     job.application match {
-      case ApplicationEmail(_) => 
+      case ApplicationEmail(_) =>
         """Use the button below to send us an email including your CV, the position you're applying for, and anything else you might want to say."""
-      case ApplicationURL(_)   => 
+      case ApplicationURL(_)   =>
         """Apply online. Click "Apply Now" below to get started."""
     }
 
@@ -23,8 +23,13 @@ object Markdown {
       case OnSite        => "No"
     }
 
-  def juniorMeta(job: Job): String = 
+  def juniorMeta(job: Job): String =
     if (job.level contains "Junior") "junior: true" else ""
+
+  def citizenMeta(job: Job): String = job.citizenship match {
+    case Some(c) => s"citizenship: |\n  $c"
+    case None    => ""
+  }
 
   def apply(job: Job): String =
       s"""
@@ -43,6 +48,7 @@ object Markdown {
       |instructions: |
       |  ${instructionsText(job)}
       |${juniorMeta(job)}
+      |${citizenMeta(job)}
       |---
       |
       |<!-- break -->

--- a/src/test/scala/io/underscore/jobby/converter-spec.scala
+++ b/src/test/scala/io/underscore/jobby/converter-spec.scala
@@ -30,4 +30,11 @@ class ConverterSpec extends FlatSpec with Matchers with TryValues {
     )
   }
 
+  it should "Succeed if there are not enough values at runtime but the remaining fields are optional" in {
+    val converter = implicitly[Converter[String :: Option[String] :: HNil]]
+    converter.convert(List("x")).success.value should be(
+      "x" :: (None:Option[String]) :: HNil
+    )
+  }
+
 }


### PR DESCRIPTION
When we added the Citizenship question for the jobs form, it was marked as optional. That means it shows up at the end of the data from Google, and it may be omitted (i.e., we get rows of data from Google that are now variable length).

That's fine, we model the column as an `Option[T]`. When we "run out of data" reading a column, if the field is an `Option[T]` we allow this and use `None` as the field value and carry on processing.

The end result is a yaml header that includes:

```
citizenship: |
  US Citizens; visa sponsorship available
```

...for example.

Fixes #7 