### PR TITLE
Updates for scalax 2017

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "jobby"
 
 version := "1.0.0"
 
-scalaVersion := "2.12.0"
+scalaVersion := "2.12.2"
 
 val google = Seq(
   "com.google.api-client"   % "google-api-client"          % "1.22.0",

--- a/src/main/scala/io/underscore/jobby/LocalMain.scala
+++ b/src/main/scala/io/underscore/jobby/LocalMain.scala
@@ -1,0 +1,7 @@
+package io.underscore.jobby
+
+object LocalMain {
+  def main(args: Array[String]): Unit = 
+    Main.main(Array("1UN12o-LP3EFFw5VjeiP27om99_TmuFs3Pm9O1isinxY", "Form Responses 1!A2:L"))
+}
+

--- a/src/main/scala/io/underscore/jobby/quickstart.scala
+++ b/src/main/scala/io/underscore/jobby/quickstart.scala
@@ -8,17 +8,14 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.http.HttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.api.client.json.JsonFactory
 import com.google.api.client.util.store.FileDataStoreFactory
 import com.google.api.services.sheets.v4.SheetsScopes
 import com.google.api.services.sheets.v4.model._
 import com.google.api.services.sheets.v4.Sheets
 
-import java.io.IOException
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.util.Arrays
-import java.util.{List => JList}
 
 import scala.collection.JavaConverters._
 import scala.util.{Try,Success,Failure}

--- a/src/main/scala/io/underscore/jobby/scalax.scala
+++ b/src/main/scala/io/underscore/jobby/scalax.scala
@@ -1,37 +1,62 @@
 package io.underscore.jobby
 
-import java.util.Arrays
-import java.util.{List => JList}
-
 import scala.collection.JavaConverters._
 import scala.util.{Try,Success,Failure}
 
 case class Talk(
-  status         : String,
   number         : Int,
+  timestamp      : String,
   title          : String,
-  summary        : String,
   talkType       : String,
+  summary        : String,
   audienceLevel  : String,
-  author         : String,
   classification : String,
-  location       : String,
-  email          : String,
-  twitter        : String,
-  plus           : String,
-  phone          : String,
-  organization   : String,
-  locationAgain  : String,
-  bio            : String
+  author         : String,
 )
 
+object Config {
+  val sheetId = "1pI-BYpRlT1UiUMukyUytwdAv7uPFZHR147jLtN8hGDs"
+  val sheetRange = "CFP!A2:H"
+  val outDir = "/Users/richard/tmp/cfp/content/post"
+}
 
+/*
+  Extracts Scala eXchange CFP submissions from a Google Sheet and writes 
+  them as markdown to the file system.
+ 
+  Best used with a static site generator, such as hugo.
+ 
+  The `Talk` class above defines the columns of interest in the sheet.
+  The `sheetId` and `sheetRange` must correspond to the CFP
+  sheet and the range of columns to match against the `Talk` case class.
+ 
+  To use wth hugo:
+ 
+ 
+  1, Install Hugo
+  
+  ` brew install hugo` (or similar)
+ 
+  2. Create a site and give it a theme
+  ```
+  cd tmp
+  hugo new site cfp
+  cd cfp
+  mkdir content/post
+  git init 
+  git submodule add https://github.com/budparr/gohugo-theme-ananke.git themes/ananke
+  echo 'theme = "ananke"' >> config.toml
+  ``
+
+  2. Serve content
+  - hugo server
+ */
 object ScalaxMain {
 
   import Read._
 
   def main(args: Array[String]): Unit =
-    fetch("1pI-BYpRlT1UiUMukyUytwdAv7uPFZHR147jLtN8hGDs", "CFPs!A2:P") match {
+    fetch(Config.sheetId, Config.sheetRange) match {
       case Failure(err)   => err.printStackTrace()
       case Success(range) =>
         val talks: List[Try[Talk]] = asScala(range).map(Read.as[Talk])
@@ -53,10 +78,10 @@ object ScalaxMain {
 
   def write(talk: Talk): Try[Path] = Try {
     val name = s"${talk.number}.md"
-    val path = FileSystems.getDefault().getPath("/Users/richard/talks-92/scalax/content/post", name)
+    val path = FileSystems.getDefault().getPath(Config.outDir, name)
     val content = s"""
       |+++
-      |title = "${talk.number}. ${talk.status} ${talk.title}"
+      |title = "${talk.number}. ${talk.title.trim}"
       |draft = false
       |+++
       |
@@ -70,10 +95,6 @@ object ScalaxMain {
       |---
       |
       |${talk.author}
-      |
-      |${talk.organization}
-      |
-      |${talk.bio}
       |
       |""".stripMargin.trim
 

--- a/src/main/scala/io/underscore/jobby/scalax.scala
+++ b/src/main/scala/io/underscore/jobby/scalax.scala
@@ -7,6 +7,7 @@ case class Talk(
   number         : Int,
   timestamp      : String,
   title          : String,
+  status         : String,
   talkType       : String,
   summary        : String,
   audienceLevel  : String,
@@ -16,7 +17,7 @@ case class Talk(
 
 object Config {
   val sheetId = "1pI-BYpRlT1UiUMukyUytwdAv7uPFZHR147jLtN8hGDs"
-  val sheetRange = "CFP!A2:H"
+  val sheetRange = "CFP!A2:I"
   val outDir = "/Users/richard/tmp/cfp/content/post"
 }
 
@@ -85,6 +86,7 @@ object ScalaxMain {
       |draft = false
       |+++
       |
+      |- Status: ${talk.status}
       |- ${talk.talkType}
       |- ${talk.classification}
       |- ${talk.audienceLevel}

--- a/src/test/scala/io/underscore/jobby/converter-spec.scala
+++ b/src/test/scala/io/underscore/jobby/converter-spec.scala
@@ -1,7 +1,6 @@
 package io.underscore.jobby
 
 import org.scalatest._
-import scala.util.{ Success, Failure }
 import java.time.Instant
 import shapeless.{HNil, ::}
 

--- a/src/test/scala/io/underscore/jobby/parsing-spec.scala
+++ b/src/test/scala/io/underscore/jobby/parsing-spec.scala
@@ -1,9 +1,8 @@
 package io.underscore.jobby
 
 import org.scalatest._
-import scala.util.{ Try, Success, Failure }
+import scala.util.{ Success, Failure }
 import java.time.Instant
-import shapeless._
 
 class ParsingSpec extends FlatSpec with Matchers {
 


### PR DESCRIPTION
For Scala eXchange, the CFP are written into a google sheet.  (Sound familiar?) I'm using Jobby infrastructure to extract the CFP submissions to markdown, so I can view them easily (as opposed to trying to look at large chunks of text in a spreadsheet). 

This PR...

- Updates the scalax.scala code for changes in columns in the scalax google sheet
- Moves us up to [Scala 2.12.2](https://github.com/scala/scala/releases/tag/v2.12.2)
- Removes unused imports which, as of 2.12.2, are fatal with the compiler flags we have.  We should probably cargo cult [the polecat](http://tpolecat.github.io/2017/04/25/scalac-flags.html).